### PR TITLE
ci: improve release automation

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,9 +12,12 @@ jobs:
         id: release
         with:
           # use the CI token to pretend not to be a action
-          # token: ${{ secrets.CONTIAMO_CI_TOKEN }}
+          token: ${{ secrets.CI_RELEASER_TOKEN }}
           release-type: go
           package-name: ""
+          extra-files: |
+            chart/Chart.yaml
+            chart/values.yaml
           changelog-types: |
             [
               {"type":"feat","section":"Features","hidden":false},

--- a/chart/openfaas-loki/Chart.yaml
+++ b/chart/openfaas-loki/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.0.1"
+appVersion: "0.0.1" # x-release-please-version
 version: 0.1.1
 name: openfaas-loki
 description: A Loki powered log provider for OpenFaaS
 maintainers:
-    - name: Lucas Roesler
-      url: https://lucasroesler.com
+  - name: Lucas Roesler
+    url: https://lucasroesler.com

--- a/chart/openfaas-loki/values.yaml
+++ b/chart/openfaas-loki/values.yaml
@@ -10,7 +10,7 @@ timeout: 30s
 
 image:
   repository: ghcr.io/lucasroesler/openfaas-loki
-  tag: v1.5.0
+  tag: v1.5.0 # x-release-please-version
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
Improve release automation by using a PAT with the release please
action, this will ensure that the PRs and the Tags created by the action
will trigger the dependent actions.

Also, add annotations to automatically update the app version in the
chart.yaml and the values.yaml

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>